### PR TITLE
Trim whitespace

### DIFF
--- a/src/main/java/nz/ac/auckland/cer/account/controller/RequestAccountController.java
+++ b/src/main/java/nz/ac/auckland/cer/account/controller/RequestAccountController.java
@@ -109,7 +109,7 @@ public class RequestAccountController {
             String tuakiriIdpUrl = (String) request.getAttribute("Shib-Identity-Provider");
             String tuakiriSharedToken = (String) request.getAttribute("shared-token");
             String eppn = (String) request.getAttribute("eppn");
-            String userDN = this.slcs.createUserDn(tuakiriIdpUrl, ar.getFullName(), tuakiriSharedToken);
+            String userDN = this.slcs.createUserDn(tuakiriIdpUrl, ar.getFullName(), tuakiriSharedToken).trim();
             Researcher r = this.createResearcherFromFormData(ar);
             String accountName = util.createAccountName(eppn, r.getFullName());
             r.setId(this.pdDao.createResearcher(r));


### PR DESCRIPTION
Somehow a tab character got added to the front of a recent DN. This commit will trim leading and trailing whitespace from generated userDNs.
